### PR TITLE
Renaming ManageIQ::Api::Client to ManageIQ::API::Client

### DIFF
--- a/lib/manageiq/api/client.rb
+++ b/lib/manageiq/api/client.rb
@@ -1,7 +1,7 @@
 require "manageiq/api/client/version"
 
 module ManageIQ
-  module Api
+  module API
     module Client
       # Your code goes here...
     end

--- a/lib/manageiq/api/client/version.rb
+++ b/lib/manageiq/api/client/version.rb
@@ -1,5 +1,5 @@
 module ManageIQ
-  module Api
+  module API
     module Client
       VERSION = "0.1.0".freeze
     end

--- a/manageiq-api-client.gemspec
+++ b/manageiq-api-client.gemspec
@@ -5,7 +5,7 @@ require 'manageiq/api/client/version'
 
 Gem::Specification.new do |spec|
   spec.name          = "manageiq-api-client"
-  spec.version       = ManageIQ::Api::Client::VERSION
+  spec.version       = ManageIQ::API::Client::VERSION
   spec.authors       = ["Alberto Bellotti"]
   spec.email         = ["abellott@redhat.com"]
 

--- a/spec/manageiq/api/client_spec.rb
+++ b/spec/manageiq/api/client_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
-describe ManageIQ::Api::Client do
+describe ManageIQ::API::Client do
   it 'has a version number' do
-    expect(ManageIQ::Api::Client::VERSION).not_to be nil
+    expect(ManageIQ::API::Client::VERSION).not_to be nil
   end
 end


### PR DESCRIPTION
Changing Class references (not doc) from ManageIQ::Api::Client to ManageIQ::API::Client
