### PR TITLE
Add alternate require files that match common patterns.

### DIFF
--- a/lib/manageiq-api-client.rb
+++ b/lib/manageiq-api-client.rb
@@ -1,0 +1,1 @@
+require 'manageiq/api/client'

--- a/lib/manageiq_api_client.rb
+++ b/lib/manageiq_api_client.rb
@@ -1,0 +1,1 @@
+require 'manageiq/api/client'


### PR DESCRIPTION
This is common in other gems to have various entrypoints that are named
reasonably.