### PR TITLE
Fix for README.md, Authentication takes :user and not :username.

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Or install it yourself as:
 ```ruby
 miq = ManageIQ::API::Client.new(
   :url      => "http://localhost:3000",
-  :username => "user",
+  :user     => "user",
   :password => "password"
 )
 


### PR DESCRIPTION
ManageIQ::API::Client.new(:url => ..., :user => ..., :password => ...)

Fixes #13