### PR TITLE
Added support for updating authentication

### DIFF
--- a/lib/manageiq/api/client/authentication.rb
+++ b/lib/manageiq/api/client/authentication.rb
@@ -25,7 +25,7 @@ module ManageIQ
           super.gsub(/@password=".+?"(, )?/, "")
         end
 
-        def self.options?(options)
+        def self.auth_options_specified?(options)
           options.slice(:user, :password, :token, :group).present?
         end
 

--- a/lib/manageiq/api/client/authentication.rb
+++ b/lib/manageiq/api/client/authentication.rb
@@ -25,6 +25,10 @@ module ManageIQ
           super.gsub(/@password=".+?"(, )?/, "")
         end
 
+        def self.options?(options)
+          options.slice(:user, :password, :token, :group).present?
+        end
+
         private
 
         def fetch_credentials(options)

--- a/lib/manageiq/api/client/client.rb
+++ b/lib/manageiq/api/client/client.rb
@@ -31,21 +31,20 @@ module ManageIQ
       end
 
       def update_authentication(auth_options = {})
-        return @authentication unless ManageIQ::API::Client::Authentication.options?(auth_options)
+        return @authentication unless ManageIQ::API::Client::Authentication.auth_options_specified?(auth_options)
         saved_auth = @authentication
         @authentication = ManageIQ::API::Client::Authentication.new(auth_options)
         begin
           reconnect
-        rescue => err
+        rescue
           @authentication = saved_auth
-          raise err
+          raise
         end
         @authentication
       end
 
       def reconnect
-        new_connection = ManageIQ::API::Client::Connection.new(self, options.slice(:ssl))
-        @connection = new_connection
+        @connection = ManageIQ::API::Client::Connection.new(self, options.slice(:ssl))
         load_definitions
       end
 

--- a/lib/manageiq/api/client/client.rb
+++ b/lib/manageiq/api/client/client.rb
@@ -18,8 +18,7 @@ module ManageIQ
         @options = options.dup
         @url = extract_url(options)
         @authentication = ManageIQ::API::Client::Authentication.new(options)
-        @connection = ManageIQ::API::Client::Connection.new(url, authentication, options.slice(:ssl))
-        load_definitions
+        reconnect
       end
 
       def load_definitions
@@ -29,6 +28,25 @@ module ManageIQ
         @identity      = ManageIQ::API::Client::Identity.new(entrypoint["identity"])
         @authorization = Hash(entrypoint["authorization"]).dup
         @collections   = load_collections(entrypoint["collections"])
+      end
+
+      def update_authentication(auth_options = {})
+        return @authentication unless ManageIQ::API::Client::Authentication.options?(auth_options)
+        saved_auth = @authentication
+        @authentication = ManageIQ::API::Client::Authentication.new(auth_options)
+        begin
+          reconnect
+        rescue => err
+          @authentication = saved_auth
+          raise err
+        end
+        @authentication
+      end
+
+      def reconnect
+        new_connection = ManageIQ::API::Client::Connection.new(self, options.slice(:ssl))
+        @connection = new_connection
+        load_definitions
       end
 
       delegate :get, :post, :put, :patch, :delete, :error, :to => :connection

--- a/lib/manageiq/api/client/connection.rb
+++ b/lib/manageiq/api/client/connection.rb
@@ -4,16 +4,18 @@ module ManageIQ
       class Connection
         attr_accessor :url
         attr_accessor :authentication
+        attr_accessor :client
         attr_accessor :options
         attr_accessor :response
         attr_accessor :error
 
+        delegate :url, :authentication, :to => :client
+
         API_PREFIX = "/api".freeze
         CONTENT_TYPE = "application/json".freeze
 
-        def initialize(url, authentication, connection_options = {})
-          @url = url
-          @authentication = authentication
+        def initialize(client, connection_options = {})
+          @client = client
           @options = connection_options
           @error = nil
         end


### PR DESCRIPTION
- Needed the Connection to leverage the authentication in the client object
- added the update_authentication() method in client
- updates authentication only after successful reconnect.
- Can also be used if user decides to use different token or different group for authorization.

Fixes #7