### PR TITLE
Support accessing resource attributes directly

### DIFF
--- a/lib/manageiq/api/client/resource.rb
+++ b/lib/manageiq/api/client/resource.rb
@@ -26,12 +26,12 @@ module ManageIQ
                 fetch_actions(resource_hash)
               end
 
-              define_method("method_missing") do |sym|
-                if data.key?(sym.to_s)
-                  data[sym.to_s]
-                else
-                  raise NoMethodError, "undefined method `#{sym}' for #{self}"
-                end
+              define_method("method_missing") do |sym, *args|
+                data.key?(sym.to_s) ? data[sym.to_s] : super(sym, *args)
+              end
+
+              define_method("respond_to_missing?") do |sym, *args|
+                data.key?(sym.to_s) || super(sym, *args)
               end
             end
             const_set(klass_name, klass)

--- a/lib/manageiq/api/client/resource.rb
+++ b/lib/manageiq/api/client/resource.rb
@@ -25,6 +25,14 @@ module ManageIQ
                 @data = resource_hash.except("actions")
                 fetch_actions(resource_hash)
               end
+
+              define_method("method_missing") do |sym|
+                if data.key?(sym.to_s)
+                  data[sym.to_s]
+                else
+                  raise NoMethodError, "undefined method `#{sym}' for #{self}"
+                end
+              end
             end
             const_set(klass_name, klass)
             klass


### PR DESCRIPTION
Attributes are still stored in data hash for segregation but are also accessible via method:

```ruby
   vm = miq.vms.search.last
   vm.data["cpu_shares"]
    or simply:
   vm.cpu_shares
```

Fixes #8