### PR TITLE
Remove dependency restrictions for json and more_core_extenstions

### DIFF
--- a/manageiq-api-client.gemspec
+++ b/manageiq-api-client.gemspec
@@ -38,6 +38,6 @@ Gem::Specification.new do |spec|
   spec.add_dependency "activesupport", "~> 5.0.0"
   spec.add_dependency "faraday", "~> 0.9.2"
   spec.add_dependency "faraday_middleware", "~> 0.10.0"
-  spec.add_dependency "json", "~> 1.8.3"
-  spec.add_dependency "more_core_extensions", "~> 2.0.0"
+  spec.add_dependency "json", "~> 2.0.1"
+  spec.add_dependency "more_core_extensions"
 end


### PR DESCRIPTION
This versioning was preventing us from bundling with ManageIQ

@abellotti @Fryguy please review