### PR TITLE
Disable ancestor constant search for collections and resources

### DIFF
--- a/lib/manageiq/api/client/collection.rb
+++ b/lib/manageiq/api/client/collection.rb
@@ -11,8 +11,8 @@ module ManageIQ
         def self.subclass(name)
           klass_name = name.camelize
 
-          if const_defined?(klass_name)
-            const_get(klass_name)
+          if const_defined?(klass_name, false)
+            const_get(klass_name, false)
           else
             klass = Class.new(self) do
               attr_accessor :client

--- a/lib/manageiq/api/client/resource.rb
+++ b/lib/manageiq/api/client/resource.rb
@@ -11,8 +11,8 @@ module ManageIQ
         def self.subclass(name)
           klass_name = name.classify
 
-          if const_defined?(klass_name)
-            const_get(klass_name)
+          if const_defined?(klass_name, false)
+            const_get(klass_name, false)
           else
             klass = Class.new(self) do
               attr_accessor :data


### PR DESCRIPTION
This will prevent us from finding constants like `::Settings` when trying to determine if `ManageIQ::API::Client::Collection::Settings` is defined already.

I ran into this while testing the gem in the context of the manageiq app.
When I tried to initialize a client, I got the following stacktrace with an error message indicating we attempted to call `.new` on the config gem global settings object.

```
/home/ncarboni/.gem/ruby/2.3.1/bundler/gems/manageiq-api-client-4bc859de2eb1/lib/manageiq/api/client/client.rb:56:in `collect'
/home/ncarboni/.gem/ruby/2.3.1/bundler/gems/manageiq-api-client-4bc859de2eb1/lib/manageiq/api/client/client.rb:56:in `load_collections'
/home/ncarboni/.gem/ruby/2.3.1/bundler/gems/manageiq-api-client-4bc859de2eb1/lib/manageiq/api/client/client.rb:30:in `load_definitions'
/home/ncarboni/.gem/ruby/2.3.1/bundler/gems/manageiq-api-client-4bc859de2eb1/lib/manageiq/api/client/client.rb:48:in `reconnect'
/home/ncarboni/.gem/ruby/2.3.1/bundler/gems/manageiq-api-client-4bc859de2eb1/lib/manageiq/api/client/client.rb:21:in `initialize'
/home/ncarboni/Source/manageiq/app/models/mixins/process_tasks_mixin.rb:106:in `new'
```

Error:
`[NoMethodError]: undefined method 'new' for #<Config::Options api=#<Config::Options ...`

This was because `const_defined?("Settings")` would be `true` and `const_get("Settings")` would give the config settings object as the return value of `Collection.subclass("settings")` which we then tried to instantiate.

@Fryguy @abellotti please review.

