### PR TITLE
Fixes issue with single filter and working with earlier API server entrypoints

### DIFF
--- a/lib/manageiq/api/client/client.rb
+++ b/lib/manageiq/api/client/client.rb
@@ -25,8 +25,8 @@ module ManageIQ
       def load_definitions
         entrypoint     = connection.get("", :attributes => "authorization")
         @api           = ManageIQ::API::Client::API.new(entrypoint)
-        @settings      = entrypoint["settings"].dup
-        @identity      = ManageIQ::API::Client::Identity.new(entrypoint["identity"])
+        @settings      = Hash(entrypoint["settings"]).dup
+        @identity      = ManageIQ::API::Client::Identity.new(Hash(entrypoint["identity"]))
         @authorization = Hash(entrypoint["authorization"]).dup
         @collections   = load_collections(entrypoint["collections"])
       end

--- a/lib/manageiq/api/client/collection.rb
+++ b/lib/manageiq/api/client/collection.rb
@@ -30,6 +30,7 @@ module ManageIQ
 
               define_method("search") do |options = {}|
                 options[:expand] = (String(options[:expand]).split(",") | %w(resources)).join(",")
+                options[:filter] = Array(options[:filter]) if options[:filter].is_a?(String)
                 result_hash = client.get(name, options)
                 fetch_actions(result_hash)
                 klass = ManageIQ::API::Client::Resource.subclass(name)


### PR DESCRIPTION

- Bringing issue fixed by Adam in https://github.com/ManageIQ/manageiq-api-client/pull/19
supporting single string filter.
- Allow parsing of earlier API entrypoints where settings and identity are not returned.

/cc @carbonin issues we've hit today.