### PR TITLE
Simplify the creation of dynamic subclasses.

### DIFF
--- a/lib/manageiq/api/client/collection.rb
+++ b/lib/manageiq/api/client/collection.rb
@@ -11,8 +11,18 @@ module ManageIQ
 
         ACTIONS_RETURNING_RESOURCES = %w(create query).freeze
 
-        def initialize(*_args)
-          raise "Cannot instantiate a #{self.class}"
+        attr_accessor :client
+
+        attr_accessor :name
+        attr_accessor :href
+        attr_accessor :description
+        attr_accessor :actions
+
+        def initialize(client, collection_spec)
+          raise "Cannot instantiate a Collection directly" if instance_of?(Collection)
+          @client = client
+          @name, @href, @description = collection_spec.values_at("name", "href", "description")
+          clear_actions
         end
 
         def each(&block)
@@ -43,52 +53,23 @@ module ManageIQ
         end
 
         def self.subclass(name)
-          klass_name = name.camelize
+          name = name.camelize
 
-          if const_defined?(klass_name, false)
-            const_get(klass_name, false)
+          if const_defined?(name, false)
+            const_get(name, false)
           else
-            klass = Class.new(self) do
-              attr_accessor :client
+            const_set(name, Class.new(self))
+          end
+        end
 
-              attr_accessor :name
-              attr_accessor :href
-              attr_accessor :description
-              attr_accessor :actions
-
-              define_method("initialize") do |client, collection_spec|
-                @client = client
-                @name, @href, @description = collection_spec.values_at("name", "href", "description")
-                clear_actions
-              end
-
-              define_method("get") do |options = {}|
-                options[:expand] = (String(options[:expand]).split(",") | %w(resources)).join(",")
-                options[:filter] = Array(options[:filter]) if options[:filter].is_a?(String)
-                result_hash = client.get(name, options)
-                fetch_actions(result_hash)
-                klass = ManageIQ::API::Client::Resource.subclass(name)
-                result_hash["resources"].collect do |resource_hash|
-                  klass.new(self, resource_hash)
-                end
-              end
-
-              define_method("method_missing") do |sym, *args, &block|
-                get unless actions_present?
-                if action_defined?(sym)
-                  exec_action(sym, *args, &block)
-                else
-                  super(sym, *args, &block)
-                end
-              end
-
-              define_method("respond_to_missing?") do |sym, *args, &block|
-                get unless actions_present?
-                action_defined?(sym) || super(sym, *args, &block)
-              end
-            end
-
-            const_set(klass_name, klass)
+        def get(options = {})
+          options[:expand] = (String(options[:expand]).split(",") | %w(resources)).join(",")
+          options[:filter] = Array(options[:filter]) if options[:filter].is_a?(String)
+          result_hash = client.get(name, options)
+          fetch_actions(result_hash)
+          klass = ManageIQ::API::Client::Resource.subclass(name)
+          result_hash["resources"].collect do |resource_hash|
+            klass.new(self, resource_hash)
           end
         end
 
@@ -104,6 +85,20 @@ module ManageIQ
         end
 
         private
+
+        def method_missing(sym, *args, &block)
+          get unless actions_present?
+          if action_defined?(sym)
+            exec_action(sym, *args, &block)
+          else
+            super
+          end
+        end
+
+        def respond_to_missing?(sym, *_)
+          get unless actions_present?
+          action_defined?(sym) || super
+        end
 
         def parameters_from_query_relation(options)
           api_params = {}


### PR DESCRIPTION
Since the dynamic subclass inherits from the base class, and the base
class is defined to be abstract with a raise in the initialize method,
then we can just let the methods live on the base class.  There is no
need to dynamically define them.