### PR TITLE
Add support for PP

### DIFF
--- a/lib/manageiq/api/client.rb
+++ b/lib/manageiq/api/client.rb
@@ -4,6 +4,7 @@ require "faraday"
 require "faraday_middleware"
 require "json"
 require "more_core_extensions/all"
+require "pp"
 require "query_relation"
 
 require "manageiq/api/client/client"

--- a/lib/manageiq/api/client/connection.rb
+++ b/lib/manageiq/api/client/connection.rb
@@ -2,8 +2,6 @@ module ManageIQ
   module API
     class Client
       class Connection
-        include CustomInspectMixin
-
         attr_accessor :url
         attr_accessor :authentication
         attr_accessor :client

--- a/lib/manageiq/api/client/mixins/custom_inspect_mixin.rb
+++ b/lib/manageiq/api/client/mixins/custom_inspect_mixin.rb
@@ -2,22 +2,14 @@ module CustomInspectMixin
   extend ActiveSupport::Concern
 
   def inspect
-    res = "#{Kernel.instance_method(:to_s).bind(self).call.chomp!('>')} "
-    attrs = instance_variables - custom_inspect_exclusions
-    res << attrs.map { |attr| "#{attr}=#{custom_inspect_value(attr)}" }.join(", ") << ">"
+    pretty_print_inspect
   end
 
-  private
-
-  def custom_inspect_exclusions
-    self.class.const_defined?(:CUSTOM_INSPECT_EXCLUSIONS) ? self.class::CUSTOM_INSPECT_EXCLUSIONS : []
+  def pretty_print(q)
+    q.pp_object(self)
   end
 
-  def custom_inspect_value(attr)
-    value = instance_variable_get(attr)
-    case value
-    when nil, String, Array, Hash then value.inspect
-    else Kernel.instance_method(:to_s).bind(value).call.sub(">", " ...>")
-    end
+  def pretty_print_instance_variables
+    super - self.class::CUSTOM_INSPECT_EXCLUSIONS
   end
 end


### PR DESCRIPTION
Because the inspect method was overridden, Ruby's PP module (and by
extension pry's pretty printer) would not pretty print any objects
properly, instead leaving them on a single line which is hard to use.
This commit allows PP to work properly.

By happenstance it also greatly simplifies the CustomInspectMixin by
using the built-in pretty_print_inspect as the custom inspect method.
The removal of instance variables was the one feature that
CustomInspectMixin provided, but it turns out PP already has support for
that, so we can just use it.

Before

```text
> puts miq.vms.inspect

#<ManageIQ::API::Client::Collection::Vms:0x007fab1ffe2078 @name="vms", @href="http://localhost:3000/api/vms", @description="Virtual Machines", @actions=[]>

> puts miq.vms.pretty_inspect

#<ManageIQ::API::Client::Collection::Vms:0x007fab1ffe2078 @name="vms", @href="http://localhost:3000/api/vms", @description="Virtual Machines", @actions=[]>
```

After (also notice it still removes the `@client` as it did in the Before)

```text
> puts miq.vms.inspect

#<ManageIQ::API::Client::Collection::Vms:0x007fda94ba9e08 @actions=[], @description="Virtual Machines", @href="http://localhost:3000/api/vms", @name="vms">

> puts miq.vms.pretty_inspect

#<ManageIQ::API::Client::Collection::Vms:0x007fda94ba9e08
 @actions=[],
 @description="Virtual Machines",
 @href="http://localhost:3000/api/vms",
 @name="vms">
```