### PR TITLE
Adding support for pluck

### DIFF
--- a/lib/manageiq/api/client/collection.rb
+++ b/lib/manageiq/api/client/collection.rb
@@ -52,6 +52,10 @@ module ManageIQ
           limit(1).where(args).first
         end
 
+        def pluck(*attrs)
+          select(*attrs).to_a.pluck(*attrs)
+        end
+
         def self.subclass(name)
           name = name.camelize
 

--- a/lib/manageiq/api/client/resource.rb
+++ b/lib/manageiq/api/client/resource.rb
@@ -31,6 +31,11 @@ module ManageIQ
           fetch_actions(resource_hash)
         end
 
+        def [](attr)
+          attr_str = attr.to_s
+          attributes[attr_str] if attributes.key?(attr_str)
+        end
+
         private
 
         def method_missing(sym, *args, &block)


### PR DESCRIPTION
Now can pluck one or more attributes of a collection efficiently.

Examples:
- miq.vms.pluck(:id)
- miq.vms.pluck(:id, :name, :vendor)

Solves #33
