### PR TITLE
Handle case where nil was sent as an argument to the resource action

### DIFF
--- a/lib/manageiq/api/client/resource.rb
+++ b/lib/manageiq/api/client/resource.rb
@@ -48,7 +48,8 @@ module ManageIQ
           attributes.key?(sym.to_s) || action_defined?(sym) || super
         end
 
-        def exec_action(name, args = {}, &block)
+        def exec_action(name, args = nil, &block)
+          args ||= {}
           raise "Action #{name} parameters must be a hash" if !args.kind_of?(Hash)
           action = find_action(name)
           res = client.send(action.method, URI(action.href)) do


### PR DESCRIPTION
while we were defaulting args to {}, we were not handling
case where the args were sent in as nil.
