### PR TITLE
Fix ManageIQ::API::Client::Error to support the Rails errors (routing, etc)

### DIFF
--- a/lib/manageiq/api/client/error.rb
+++ b/lib/manageiq/api/client/error.rb
@@ -18,9 +18,13 @@ module ManageIQ
         def update(status, json_response = {})
           @status = status
           @kind, @message, @klass = nil
-          error_hash = json_response["error"]
-          if status >= 400 && error_hash.present?
-            @kind, @message, @klass = error_hash.values_at("kind", "message", "klass")
+          error = json_response["error"]
+          if status >= 400 && error.present?
+            if error.kind_of?(Hash)
+              @kind, @message, @klass = error.values_at("kind", "message", "klass")
+            else
+              @message = error
+            end
           end
         end
       end


### PR DESCRIPTION

We need to enhance the Client to support Rails errors (they simply come in
as string) in addition to the API error signature.

- Before the fix

  miq.get("bogus_collection")
  NoMethodError: undefined method `values_at' for "Not Found":String
  from /Users/abellotti/projects/manageiq-api-client/lib/manageiq/api/client/error.rb:23:in `update'
  miq.error
  => nil

- After the fix.

  miq.get("bogus_collection")
  RuntimeError: Not Found
  from /Users/abellotti/projects/manageiq-api-client/lib/manageiq/api/client/connection.rb:104:in `check_response'
  miq.error
  => #<ManageIQ::API::Client::Error:0x007fcd274c77b8 @kind=nil, @klass=nil, @message="Not Found", @status=404>
