### PR TITLE
When fetching the entrypoint a / is appended to the URL.

### DIFF
--- a/lib/manageiq/api/client/connection.rb
+++ b/lib/manageiq/api/client/connection.rb
@@ -60,6 +60,8 @@ module ManageIQ
         def api_path(path)
           if path.to_s.starts_with?(url.to_s)
             path.to_s
+          elsif path.to_s.blank?
+            URI.join(url, API_PREFIX).to_s
           else
             URI.join(url, path.to_s.starts_with?(API_PREFIX) ? path.to_s : "#{API_PREFIX}/#{path}").to_s
           end


### PR DESCRIPTION
while this works, it is confusing to see in webmock stubs and such.
requests are made as:

```
http://localhost:3000/api/?attributes=authorization
```

with this fix they are just

```
http://localhost:3000/api?attributes=authorization
```
