### PR TITLE
Loosen ActiveSupport dependency

### DIFF
--- a/manageiq-api-client.gemspec
+++ b/manageiq-api-client.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.0"
 
-  spec.add_dependency "activesupport", "~> 5.0.0"
+  spec.add_dependency "activesupport", "~> 5.0"
   spec.add_dependency "faraday", "~> 0.9.2"
   spec.add_dependency "faraday_middleware", "~> 0.10.0"
   spec.add_dependency "json", "~> 2.0.1"


### PR DESCRIPTION
Loosens AS dependency, as it doesn't need to restrict minor versions. This allows for us to try out the new Rails 5.1 beta.