### PR TITLE
Restrict AS minor, but allow for prerelease

### DIFF
--- a/manageiq-api-client.gemspec
+++ b/manageiq-api-client.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.0"
 
-  spec.add_dependency "activesupport", "~> 5.0"
+  spec.add_dependency "activesupport", ">= 5.0", "< 5.1"
   spec.add_dependency "faraday", "~> 0.9.2"
   spec.add_dependency "faraday_middleware", "~> 0.10.0"
   spec.add_dependency "json", "~> 2.0.1"


### PR DESCRIPTION
On second thought, this is better.

This still restricts the minor version as Rails doesn't actually follow
semver and no changes between minor versions is NOT guaranteed - yet
still allows for beta versions of the next minor to be used.