### PR TITLE
Enhanced ServerInfo to support the new _href entries.

### DIFF
--- a/lib/manageiq/api/client/server_info.rb
+++ b/lib/manageiq/api/client/server_info.rb
@@ -5,10 +5,13 @@ module ManageIQ
         attr_reader :version
         attr_reader :build
         attr_reader :appliance
+        attr_reader :server_href
+        attr_reader :zone_href
+        attr_reader :region_href
 
         def initialize(server_info)
-          @version, @build, @appliance =
-            server_info.values_at("version", "build", "appliance")
+          @version, @build, @appliance, @server_href, @zone_href, @region_href =
+            server_info.values_at("version", "build", "appliance", "server_href", "zone_href", "region_href")
         end
       end
     end

--- a/spec/fixtures/api/responses/entrypoint.json
+++ b/spec/fixtures/api/responses/entrypoint.json
@@ -135,7 +135,10 @@
   "server_info": {
     "version": "master",
     "build": "20161128163232_af1ffc1",
-    "appliance": "EVM"
+    "appliance": "EVM",
+    "server_href": "http://localhost:3000/api/servers/1",
+    "zone_href": "http://localhost:3000/api/zones/1",
+    "region_href": "http://localhost:3000/api/regions/1"
   },
   "product_info": {
     "name": "ManageIQ",

--- a/spec/manageiq/api/client_spec.rb
+++ b/spec/manageiq/api/client_spec.rb
@@ -171,9 +171,12 @@ describe ManageIQ::API::Client do
       miq = described_class.new
 
       expect(miq.server_info).to be_a(ManageIQ::API::Client::ServerInfo)
-      expect(miq.server_info.appliance).to eq(server_info["appliance"])
-      expect(miq.server_info.build).to     eq(server_info["build"])
-      expect(miq.server_info.version).to   eq(server_info["version"])
+      expect(miq.server_info.appliance).to   eq(server_info["appliance"])
+      expect(miq.server_info.build).to       eq(server_info["build"])
+      expect(miq.server_info.version).to     eq(server_info["version"])
+      expect(miq.server_info.server_href).to eq(server_info["server_href"])
+      expect(miq.server_info.zone_href).to   eq(server_info["zone_href"])
+      expect(miq.server_info.region_href).to eq(server_info["region_href"])
     end
 
     it "exposes product_info" do


### PR DESCRIPTION
Enhanced ServerInfo to support the new _href entries.

Adds the following attributes:
  - server_href
  - zone_href
  - region_href
Updated fixture so the new entries are exercised in the rspecs.
Updated client rspecs

