### PR TITLE
Raw query filtering by id doesn't raise when not found

### DIFF
--- a/lib/manageiq/api/client/collection.rb
+++ b/lib/manageiq/api/client/collection.rb
@@ -39,12 +39,9 @@ module ManageIQ
           when 0
             raise "Couldn't find resource without an 'id'"
           when 1
-            begin
-              res = limit(1).where(:id => args[0]).to_a
-              request_array ? res : res.first
-            rescue => err
-              raise ManageIQ::API::Client::ResourceNotFound, "Couldn't find resource with 'id' #{args}"
-            end
+            res = limit(1).where(:id => args[0]).to_a
+            raise ManageIQ::API::Client::ResourceNotFound, "Couldn't find resource with 'id' #{args}" if res.blank?
+            request_array ? res : res.first
           else
             raise "Multiple resource find is not supported" unless respond_to?(:query)
             query(args.collect { |id| { "id" => id } })

--- a/spec/fixtures/api/responses/filter_vms_id_9999_not_found.json
+++ b/spec/fixtures/api/responses/filter_vms_id_9999_not_found.json
@@ -1,0 +1,135 @@
+{
+  "name": "vms",
+  "count": 74,
+  "subcount": 0,
+  "subquery_count": 0,
+  "pages": 0,
+  "resources": [],
+  "actions": [
+    {
+      "name": "query",
+      "method": "post",
+      "href": "https://example.com/api/vms"
+    },
+    {
+      "name": "edit",
+      "method": "post",
+      "href": "https://example.com/api/vms"
+    },
+    {
+      "name": "add_lifecycle_event",
+      "method": "post",
+      "href": "https://example.com/api/vms"
+    },
+    {
+      "name": "add_event",
+      "method": "post",
+      "href": "https://example.com/api/vms"
+    },
+    {
+      "name": "refresh",
+      "method": "post",
+      "href": "https://example.com/api/vms"
+    },
+    {
+      "name": "shutdown_guest",
+      "method": "post",
+      "href": "https://example.com/api/vms"
+    },
+    {
+      "name": "reboot_guest",
+      "method": "post",
+      "href": "https://example.com/api/vms"
+    },
+    {
+      "name": "start",
+      "method": "post",
+      "href": "https://example.com/api/vms"
+    },
+    {
+      "name": "stop",
+      "method": "post",
+      "href": "https://example.com/api/vms"
+    },
+    {
+      "name": "suspend",
+      "method": "post",
+      "href": "https://example.com/api/vms"
+    },
+    {
+      "name": "shelve",
+      "method": "post",
+      "href": "https://example.com/api/vms"
+    },
+    {
+      "name": "shelve_offload",
+      "method": "post",
+      "href": "https://example.com/api/vms"
+    },
+    {
+      "name": "pause",
+      "method": "post",
+      "href": "https://example.com/api/vms"
+    },
+    {
+      "name": "request_console",
+      "method": "post",
+      "href": "https://example.com/api/vms"
+    },
+    {
+      "name": "reset",
+      "method": "post",
+      "href": "https://example.com/api/vms"
+    },
+    {
+      "name": "retire",
+      "method": "post",
+      "href": "https://example.com/api/vms"
+    },
+    {
+      "name": "request_retire",
+      "method": "post",
+      "href": "https://example.com/api/vms"
+    },
+    {
+      "name": "set_owner",
+      "method": "post",
+      "href": "https://example.com/api/vms"
+    },
+    {
+      "name": "set_ownership",
+      "method": "post",
+      "href": "https://example.com/api/vms"
+    },
+    {
+      "name": "set_miq_server",
+      "method": "post",
+      "href": "https://example.com/api/vms"
+    },
+    {
+      "name": "scan",
+      "method": "post",
+      "href": "https://example.com/api/vms"
+    },
+    {
+      "name": "delete",
+      "method": "post",
+      "href": "https://example.com/api/vms"
+    },
+    {
+      "name": "assign_tags",
+      "method": "post",
+      "href": "https://example.com/api/vms"
+    },
+    {
+      "name": "unassign_tags",
+      "method": "post",
+      "href": "https://example.com/api/vms"
+    }
+  ],
+  "links": {
+    "self": "https://example.com/api/vms?expand=resources&filter[]=id=9999&limit=1&offset=0",
+    "first": "https://example.com/api/vms?expand=resources&filter[]=id=9999&limit=1&offset=0",
+    "last": "https://example.com/api/vms?expand=resources&filter[]=id=9999&limit=1&offset=0"
+  }
+}

--- a/spec/manageiq/api/collection_spec.rb
+++ b/spec/manageiq/api/collection_spec.rb
@@ -31,7 +31,7 @@ describe ManageIQ::API::Client::Collection do
     it "with id, but no record exists raises a useful exception" do
       find_url = "#{api_url}/vms?expand=resources&filter%5B%5D=id=9999&limit=1"
       stub_request(:get, entrypoint_request_url).to_return(:status => 200, :body => entrypoint_response, :headers => {})
-      stub_request(:get, find_url).to_return(:status => 404, :body => api_file_fixture("responses/error_vms_9999_not_found.json"), :headers => {})
+      stub_request(:get, find_url).to_return(:status => 200, :body => api_file_fixture("responses/filter_vms_id_9999_not_found.json"), :headers => {})
 
       expect { ManageIQ::API::Client.new.vms.find(9999) }.to raise_error(ManageIQ::API::Client::ResourceNotFound, "Couldn't find resource with 'id' [9999]")
     end


### PR DESCRIPTION
Instead, we need to raise when the result is a blank array
Add a new response JSON for this example
Partially reverts changes in 923267d9ef29b846210388334b57f70e02ad94cc

https://bugzilla.redhat.com/show_bug.cgi?id=1599754

Previously resulted inrequeueing due to error:
```
[----] I, [2019-02-18T20:02:25.832748 #16963:adcf64]  INFO -- : MIQ(MiqQueue#deliver) Message id: [99000000001518], Delivering...
[----] E, [2019-02-18T20:02:26.492599 #16963:adcf64] ERROR -- : An error occurred while invoking remote tasks...Requeueing for 1 minute from now.
[----] E, [2019-02-18T20:02:26.494510 #16963:adcf64] ERROR -- : [NoMethodError]: undefined method `id' for nil:NilClass  Method:[rescue in block in invoke_tasks_remote]
[----] E, [2019-02-18T20:02:26.494756 #16963:adcf64] ERROR -- : /var/www/miq/vmdb/app/models/mixins/process_tasks_mixin.rb:127:in `block (2 levels) in invoke_api_tasks'
/var/www/miq/vmdb/lib/vmdb/logging.rb:22:in `block (3 levels) in <class:LogProxy>'
/usr/share/ruby/logger.rb:463:in `add'
/opt/rh/cfme-gemset/gems/activerecord-session_store-1.1.1/lib/active_record/session_store/extension/logger_silencer.rb:38:in `add_with_threadsafety'
/usr/share/ruby/logger.rb:525:in `info'
/var/www/miq/vmdb/lib/vmdb/logging.rb:21:in `block (2 levels) in <class:LogProxy>'
/var/www/miq/vmdb/app/models/mixins/process_tasks_mixin.rb:127:in `block in invoke_api_tasks'
/var/www/miq/vmdb/app/models/mixins/process_tasks_mixin.rb:121:in `each'
/var/www/miq/vmdb/app/models/mixins/process_tasks_mixin.rb:121:in `invoke_api_tasks'
/var/www/miq/vmdb/app/models/mixins/process_tasks_mixin.rb:70:in `block in invoke_tasks_remote'
/var/www/miq/vmdb/app/models/mixins/process_tasks_mixin.rb:65:in `each'
/var/www/miq/vmdb/app/models/mixins/process_tasks_mixin.rb:65:in `invoke_tasks_remote'
/var/www/miq/vmdb/app/models/miq_queue.rb:455:in `block in dispatch_method'
/usr/share/ruby/timeout.rb:93:in `block in timeout'
/usr/share/ruby/timeout.rb:33:in `block in catch'
/usr/share/ruby/timeout.rb:33:in `catch'
/usr/share/ruby/timeout.rb:33:in `catch'
/usr/share/ruby/timeout.rb:108:in `timeout'
/var/www/miq/vmdb/app/models/miq_queue.rb:453:in `dispatch_method'
/var/www/miq/vmdb/app/models/miq_queue.rb:430:in `block in deliver'
/var/www/miq/vmdb/app/models/user.rb:268:in `with_user'
/var/www/miq/vmdb/app/models/user.rb:283:in `with_user_group'
/var/www/miq/vmdb/app/models/miq_queue.rb:430:in `deliver'
.....
[----] I, [2019-02-18T20:02:26.522616 #16963:adcf64]  INFO -- : MIQ(MiqQueue.put) Message id: [99000000001519],  id: [], Zone: [default], Role: [], Server: [], MiqTask id: [], Ident: [generic], Target id: [], Instance id: [], Task id: [], Command: [Vm.invoke_tasks_remote], Timeout: [600], Priority: [100], State: [ready], Deliver On: [2019-02-19 01:03:26 UTC], Data: [], Args: [{:ids=>[1000000000050], :task=>"start", :userid=>"admin", :miq_task_id=>nil}]
[----] I, [2019-02-18T20:02:26.523016 #16963:adcf64]  INFO -- : MIQ(MiqQueue#delivered) Message id: [99000000001518], State: [ok], Delivered in [0.690275208] seconds
```

Now, task is not requeued because the proper error is raised and caught where expected:
```
[----] I, [2019-02-18T22:23:07.617209 #24563:3b4f5c]  INFO -- : MIQ(MiqQueue#deliver) Message id: [99000000001519], Delivering...
[----] E, [2019-02-18T22:23:08.410421 #24563:3b4f5c] ERROR -- : MIQ(Vm.invoke_api_tasks) Couldn't find resource with 'id' [1000000000050]
[----] I, [2019-02-18T22:23:08.465237 #24563:3b4f5c]  INFO -- : <AuditSuccess> MIQ(ProcessTasksMixin.task_audit_event) userid: [admin] - 'start' successfully initiated for remote VMs: [1000000000050]
[----] I, [2019-02-18T22:23:08.465556 #24563:3b4f5c]  INFO -- : MIQ(MiqQueue#delivered) Message id: [99000000001519], State: [ok], Delivered in [0.848421767] seconds
```