### PR TITLE
Relax requirement as ActiveSupport::Concern is stable.

### DIFF
--- a/manageiq-api-client.gemspec
+++ b/manageiq-api-client.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.0"
 
-  spec.add_dependency "activesupport", ">= 5.0", "< 5.3"
+  spec.add_dependency "activesupport", ">= 5.0", "< 6.1"
   spec.add_dependency "faraday", "~> 0.9"
   spec.add_dependency "faraday_middleware", "~> 0.10.0"
   spec.add_dependency "json", "~> 2.1.0"


### PR DESCRIPTION
Note, we should probably add appraisal gem to test multiple rails versions but this repo only uses AS::Concern and has very little need to test each version of rails.