### PR TITLE
Update the json gem to v2.3

### DIFF
--- a/manageiq-api-client.gemspec
+++ b/manageiq-api-client.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "activesupport", ">= 5.0", "< 6.1"
   spec.add_dependency "faraday", "~> 0.9"
   spec.add_dependency "faraday_middleware", "~> 0.10.0"
-  spec.add_dependency "json", "~> 2.1.0"
+  spec.add_dependency "json", "~> 2.3"
   spec.add_dependency "more_core_extensions"
   spec.add_dependency "query_relation"
 end


### PR DESCRIPTION
Json 2.1.0 throws _a lot_ of deprecation warnings on ruby 2.7

`~/.gems/2.7.0/gems/json-2.1.0/lib/json/common.rb:156: warning: Using the last argument as keyword parameters is deprecated`