### PR TITLE
Removing deprecated Gemnasium badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,6 @@
 [![Build Status](https://travis-ci.org/ManageIQ/manageiq-api-client.svg)](https://travis-ci.org/ManageIQ/manageiq-api-client)
 [![Code Climate](https://codeclimate.com/github/ManageIQ/manageiq-api-client.svg)](https://codeclimate.com/github/ManageIQ/manageiq-api-client)
 [![Test Coverage](https://codeclimate.com/github/ManageIQ/manageiq-api-client/badges/coverage.svg)](https://codeclimate.com/github/ManageIQ/manageiq-api-client/coverage)
-[![Dependency Status](https://gemnasium.com/ManageIQ/manageiq-api-client.svg)](https://gemnasium.com/ManageIQ/manageiq-api-client)
 [![Security](https://hakiri.io/github/ManageIQ/manageiq-api-client/master.svg)](https://hakiri.io/github/ManageIQ/manageiq-api-client/master)
 
 This gem provides Ruby access to the ManageIQ API by exposing the ManageIQ


### PR DESCRIPTION
Functionality has been replaced by GitHub's dependency graph and security alerts.