### PR TITLE
drop sudo:false

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,5 @@ language: ruby
 rvm:
   - 2.4.5
   - 2.5.3
-sudo: false
 cache: bundler
 after_script: bundle exec codeclimate-test-reporter


### PR DESCRIPTION
dropping `sudo:false` per https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration