### PR TITLE
[wip] bump activesupport

### DIFF
--- a/manageiq-api-client.gemspec
+++ b/manageiq-api-client.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake", ">= 12.3.3"
   spec.add_development_dependency "rspec", "~> 3.0"
 
-  spec.add_dependency "activesupport", ">= 5.0", "< 6.1"
+  spec.add_dependency "activesupport", ">= 5.2.4.3", "< 6.1"
   spec.add_dependency "faraday", "~> 1.0.0"
   spec.add_dependency "faraday_middleware", "~> 1.0"
   spec.add_dependency "json", "~> 2.3"


### PR DESCRIPTION
I thought this hakiri warning got fixed in >= 5.2.4.3, but, um, maybe I was mistaken.