### PR TITLE
remove deprecated codeclimate-test-reporter gem

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,4 +3,9 @@ rvm:
   - 2.4.5
   - 2.5.3
 cache: bundler
-after_script: bundle exec codeclimate-test-reporter
+before_script:
+  - curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
+  - chmod +x ./cc-test-reporter
+  - ./cc-test-reporter before-build
+after_script:
+  - ./cc-test-reporter after-build --exit-code $TRAVIS_TEST_RESULT

--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,6 @@ gemspec
 group :test do
   gem "webmock"
   gem "simplecov", :require => false
-  gem "codeclimate-test-reporter", "~> 1.0.0", :require => false
 end
 
 # Load developer specific Gemfile


### PR DESCRIPTION
```
Post-install message from codeclimate-test-reporter:

  Code Climate's codeclimate-test-reporter gem has been deprecated in favor of
  our language-agnostic unified test reporter. The new test reporter is faster,
  distributed as a static binary so dependency conflicts never occur, and
  supports parallelized CI builds & multi-language CI configurations.

  Please visit https://docs.codeclimate.com/v1.0/docs/configuring-test-coverage
  for help setting up your CI process with our new test reporter.
```

it's marked work in progress because it depends on the addition of the token re: https://github.com/ManageIQ/azure-armrest/pull/403#issuecomment-754050779

@miq-bot add_label dependencies, test 