### PR TITLE
Loosen faraday to 1.x

### DIFF
--- a/manageiq-api-client.gemspec
+++ b/manageiq-api-client.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "activesupport", ">= 5.0", "< 7.0"
-  spec.add_dependency "faraday", "~> 1.0.0"
+  spec.add_dependency "faraday", "~> 1.0"
   spec.add_dependency "faraday_middleware", "~> 1.0"
   spec.add_dependency "json", "~> 2.3"
   spec.add_dependency "more_core_extensions"


### PR DESCRIPTION
Faraday 1.0.1 was released 3/29/2020
Faraday 1.10.3 was released 1/18/2023
(it is not in the new 2.x branch, but it is more up to date. following SemVer seemed like the least amount of work)

This resolves the following warnings

```
Top level ::CompositeIO is deprecated, require 'multipart/post' and use `Multipart::Post::CompositeReadIO` instead!
Top level ::Parts is deprecated, require 'multipart/post' and use `Multipart::Post::Parts` instead!
```