### PR TITLE
Add Bearer token support

### DIFF
--- a/lib/manageiq/api/client/authentication.rb
+++ b/lib/manageiq/api/client/authentication.rb
@@ -6,6 +6,7 @@ module ManageIQ
         attr_reader :password
         attr_reader :token
         attr_reader :miqtoken
+        attr_reader :bearer_token
         attr_reader :group
 
         DEFAULTS = {
@@ -13,26 +14,26 @@ module ManageIQ
           :password => "smartvm"
         }.freeze
 
-        CUSTOM_INSPECT_EXCLUSIONS = [:@password].freeze
+        CUSTOM_INSPECT_EXCLUSIONS = %i[@password @token @miqtoken @bearer_token].freeze
         include CustomInspectMixin
 
         def initialize(options = {})
           @user, @password = fetch_credentials(options)
-          @token, @miqtoken, @group = options.values_at(:token, :miqtoken, :group)
+          @token, @miqtoken, @bearer_token, @group = options.values_at(:token, :miqtoken, :bearer_token, :group)
 
-          unless token || miqtoken
+          unless token || miqtoken || bearer_token
             raise "Must specify both a user and a password" if user.blank? || password.blank?
           end
         end
 
         def self.auth_options_specified?(options)
-          options.slice(:user, :password, :token, :miqtoken, :group).present?
+          options.slice(:user, :password, :token, :miqtoken, :bearer_token, :group).present?
         end
 
         private
 
         def fetch_credentials(options)
-          if options.slice(:user, :password, :token, :miqtoken).blank?
+          if options.slice(:user, :password, :token, :miqtoken, :bearer_token).blank?
             [DEFAULTS[:user], DEFAULTS[:password]]
           else
             [options[:user], options[:password]]

--- a/lib/manageiq/api/client/connection.rb
+++ b/lib/manageiq/api/client/connection.rb
@@ -76,7 +76,7 @@ module ManageIQ
             faraday.response(:logger, client.logger)
             faraday.use FaradayMiddleware::FollowRedirects, :limit => 3, :standards_compliant => true
             faraday.adapter(Faraday.default_adapter) # make requests with Net::HTTP
-            if authentication.token.blank? && authentication.miqtoken.blank?
+            if authentication.token.blank? && authentication.miqtoken.blank? && authentication.bearer_token.blank?
               faraday.basic_auth(authentication.user, authentication.password)
             end
           end
@@ -90,6 +90,7 @@ module ManageIQ
             @response = handle.run_request(method.to_sym, api_path(path), nil, nil) do |request|
               request.headers[:content_type]  = CONTENT_TYPE
               request.headers[:accept]        = CONTENT_TYPE
+              request.headers[:authorization] = "Bearer #{authentication.bearer_token}" unless authentication.bearer_token.blank?
               request.headers['X-MIQ-Group']  = authentication.group unless authentication.group.blank?
               request.headers['X-Auth-Token'] = authentication.token unless authentication.token.blank?
               request.headers['X-MIQ-Token']  = authentication.miqtoken unless authentication.miqtoken.blank?

--- a/spec/manageiq/api/authentication_spec.rb
+++ b/spec/manageiq/api/authentication_spec.rb
@@ -29,9 +29,13 @@ describe ManageIQ::API::Client::Authentication do
     it "creates a new authentication with a system token" do
       expect(described_class.new(:miqtoken => "miq_token").miqtoken).to eq("miq_token")
     end
+
+    it "creates a new authentication with a bearer token" do
+      expect(described_class.new(:bearer_token => "bearer_token").bearer_token).to eq("bearer_token")
+    end
   end
 
-  describe ".auth_options_specified" do
+  describe ".auth_options_specified?" do
     it "returns true with credentials" do
       expect(described_class.auth_options_specified?(:user => "user", :password => "pass")).to be_truthy
     end
@@ -42,6 +46,10 @@ describe ManageIQ::API::Client::Authentication do
 
     it "returns true with miqtoken" do
       expect(described_class.auth_options_specified?(:miqtoken => "miqtoken")).to be_truthy
+    end
+
+    it "returns true with bearer_token" do
+      expect(described_class.auth_options_specified?(:bearer_token => "bearer_token")).to be_truthy
     end
 
     it "returns true with group" do

--- a/spec/manageiq/api/client_spec.rb
+++ b/spec/manageiq/api/client_spec.rb
@@ -42,11 +42,12 @@ describe ManageIQ::API::Client do
       miq = described_class.new
 
       expect(miq).to be_a(described_class)
-      expect(miq.authentication.user).to     eq("admin")
-      expect(miq.authentication.password).to eq("smartvm")
-      expect(miq.authentication.group).to    be_nil
-      expect(miq.authentication.token).to    be_nil
-      expect(miq.authentication.miqtoken).to be_nil
+      expect(miq.authentication.user).to         eq("admin")
+      expect(miq.authentication.password).to     eq("smartvm")
+      expect(miq.authentication.group).to        be_nil
+      expect(miq.authentication.token).to        be_nil
+      expect(miq.authentication.miqtoken).to     be_nil
+      expect(miq.authentication.bearer_token).to be_nil
     end
 
     it "supports optional user authentication" do
@@ -57,11 +58,12 @@ describe ManageIQ::API::Client do
       miq = described_class.new(:user => "foo", :password => "bar")
 
       expect(miq).to be_a(described_class)
-      expect(miq.authentication.user).to     eq("foo")
-      expect(miq.authentication.password).to eq("bar")
-      expect(miq.authentication.group).to    be_nil
-      expect(miq.authentication.token).to    be_nil
-      expect(miq.authentication.miqtoken).to be_nil
+      expect(miq.authentication.user).to         eq("foo")
+      expect(miq.authentication.password).to     eq("bar")
+      expect(miq.authentication.group).to        be_nil
+      expect(miq.authentication.token).to        be_nil
+      expect(miq.authentication.miqtoken).to     be_nil
+      expect(miq.authentication.bearer_token).to be_nil
     end
 
     it "supports optional user token" do
@@ -72,11 +74,12 @@ describe ManageIQ::API::Client do
       miq = described_class.new(:token => "user_token")
 
       expect(miq).to be_a(described_class)
-      expect(miq.authentication.user).to     be_nil
-      expect(miq.authentication.password).to be_nil
-      expect(miq.authentication.group).to    be_nil
-      expect(miq.authentication.token).to    eq("user_token")
-      expect(miq.authentication.miqtoken).to be_nil
+      expect(miq.authentication.user).to         be_nil
+      expect(miq.authentication.password).to     be_nil
+      expect(miq.authentication.group).to        be_nil
+      expect(miq.authentication.token).to        eq("user_token")
+      expect(miq.authentication.miqtoken).to     be_nil
+      expect(miq.authentication.bearer_token).to be_nil
     end
 
     it "supports optional system token" do
@@ -87,11 +90,28 @@ describe ManageIQ::API::Client do
       miq = described_class.new(:miqtoken => "system_token")
 
       expect(miq).to be_a(described_class)
-      expect(miq.authentication.user).to     be_nil
-      expect(miq.authentication.password).to be_nil
-      expect(miq.authentication.group).to    be_nil
-      expect(miq.authentication.token).to    be_nil
-      expect(miq.authentication.miqtoken).to eq("system_token")
+      expect(miq.authentication.user).to         be_nil
+      expect(miq.authentication.password).to     be_nil
+      expect(miq.authentication.group).to        be_nil
+      expect(miq.authentication.token).to        be_nil
+      expect(miq.authentication.miqtoken).to     eq("system_token")
+      expect(miq.authentication.bearer_token).to be_nil
+    end
+
+    it "supports optional bearer token" do
+      stub_request(:get, entrypoint_request_url)
+        .with(:headers => {:authorization => 'Bearer bearer_token'})
+        .to_return(:status => 200, :body => @entrypoint_response, :headers => {})
+
+      miq = described_class.new(:bearer_token => "bearer_token")
+
+      expect(miq).to be_a(described_class)
+      expect(miq.authentication.user).to         be_nil
+      expect(miq.authentication.password).to     be_nil
+      expect(miq.authentication.group).to        be_nil
+      expect(miq.authentication.token).to        be_nil
+      expect(miq.authentication.miqtoken).to     be_nil
+      expect(miq.authentication.bearer_token).to eq("bearer_token")
     end
 
     it "supports optional authorization group" do
@@ -102,11 +122,12 @@ describe ManageIQ::API::Client do
       miq = described_class.new(:group => "special_group")
 
       expect(miq).to be_a(described_class)
-      expect(miq.authentication.user).to     eq("admin")
-      expect(miq.authentication.password).to eq("smartvm")
-      expect(miq.authentication.group).to    eq("special_group")
-      expect(miq.authentication.token).to    be_nil
-      expect(miq.authentication.miqtoken).to be_nil
+      expect(miq.authentication.user).to         eq("admin")
+      expect(miq.authentication.password).to     eq("smartvm")
+      expect(miq.authentication.group).to        eq("special_group")
+      expect(miq.authentication.token).to        be_nil
+      expect(miq.authentication.miqtoken).to     be_nil
+      expect(miq.authentication.bearer_token).to be_nil
     end
 
     it "support open_timeout and timeout" do
@@ -219,11 +240,12 @@ describe ManageIQ::API::Client do
       miq = described_class.new
 
       expect(miq).to be_a(described_class)
-      expect(miq.authentication.user).to     eq("admin")
-      expect(miq.authentication.password).to eq("smartvm")
-      expect(miq.authentication.group).to    be_nil
-      expect(miq.authentication.token).to    be_nil
-      expect(miq.authentication.miqtoken).to be_nil
+      expect(miq.authentication.user).to         eq("admin")
+      expect(miq.authentication.password).to     eq("smartvm")
+      expect(miq.authentication.group).to        be_nil
+      expect(miq.authentication.token).to        be_nil
+      expect(miq.authentication.miqtoken).to     be_nil
+      expect(miq.authentication.bearer_token).to be_nil
 
       stub_request(:get, entrypoint_request_url)
         .with(:headers => {:x_auth_token => 'user_temporary_token'})
@@ -231,11 +253,12 @@ describe ManageIQ::API::Client do
 
       miq.update_authentication(:token => "user_temporary_token")
 
-      expect(miq.authentication.user).to     be_nil
-      expect(miq.authentication.password).to be_nil
-      expect(miq.authentication.group).to    be_nil
-      expect(miq.authentication.token).to    eq("user_temporary_token")
-      expect(miq.authentication.miqtoken).to be_nil
+      expect(miq.authentication.user).to         be_nil
+      expect(miq.authentication.password).to     be_nil
+      expect(miq.authentication.group).to        be_nil
+      expect(miq.authentication.token).to        eq("user_temporary_token")
+      expect(miq.authentication.miqtoken).to     be_nil
+      expect(miq.authentication.bearer_token).to be_nil
     end
 
     it "group re-authorization updates a client's authentication and reconnects" do
@@ -246,11 +269,12 @@ describe ManageIQ::API::Client do
       miq = described_class.new(:group => "basic_users")
 
       expect(miq).to be_a(described_class)
-      expect(miq.authentication.user).to     eq("admin")
-      expect(miq.authentication.password).to eq("smartvm")
-      expect(miq.authentication.group).to    eq("basic_users")
-      expect(miq.authentication.token).to    be_nil
-      expect(miq.authentication.miqtoken).to be_nil
+      expect(miq.authentication.user).to         eq("admin")
+      expect(miq.authentication.password).to     eq("smartvm")
+      expect(miq.authentication.group).to        eq("basic_users")
+      expect(miq.authentication.token).to        be_nil
+      expect(miq.authentication.miqtoken).to     be_nil
+      expect(miq.authentication.bearer_token).to be_nil
 
       stub_request(:get, entrypoint_request_url)
         .with(:headers => {:authorization => 'Basic YWRtaW46c21hcnR2bQ==', :x_miq_group => "super_admins"})
@@ -258,11 +282,12 @@ describe ManageIQ::API::Client do
 
       miq.update_authentication(:group => "super_admins")
 
-      expect(miq.authentication.user).to     eq("admin")
-      expect(miq.authentication.password).to eq("smartvm")
-      expect(miq.authentication.group).to    eq("super_admins")
-      expect(miq.authentication.token).to    be_nil
-      expect(miq.authentication.miqtoken).to be_nil
+      expect(miq.authentication.user).to         eq("admin")
+      expect(miq.authentication.password).to     eq("smartvm")
+      expect(miq.authentication.group).to        eq("super_admins")
+      expect(miq.authentication.token).to        be_nil
+      expect(miq.authentication.miqtoken).to     be_nil
+      expect(miq.authentication.bearer_token).to be_nil
     end
   end
 


### PR DESCRIPTION
This PR adds support for Bearer tokens when using an external auth system that requires them (such as OIDC).