### PR TITLE
Drop More core extensions and active_support dependencies

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,12 +15,7 @@ jobs:
         - '2.7'
         - '3.0'
         - '3.1'
-        rails-version:
-        - '6.0'
-        - '6.1'
-        - '7.0'
     env:
-      TEST_RAILS_VERSION: ${{ matrix.rails-version }}
       CC_TEST_REPORTER_ID: ${{ secrets.CC_TEST_REPORTER_ID }}
     steps:
     - uses: actions/checkout@v4
@@ -33,6 +28,6 @@ jobs:
     - name: Run tests
       run: bundle exec rake
     - name: Report code coverage
-      if: ${{ github.ref == 'refs/heads/master' && matrix.ruby-version == '3.0' && matrix.rails-version == '6.1' }}
+      if: ${{ github.ref == 'refs/heads/master' && matrix.ruby-version == '3.0' }}
       continue-on-error: true
       uses: paambaati/codeclimate-action@v5

--- a/Gemfile
+++ b/Gemfile
@@ -6,15 +6,3 @@ gemspec
 # Load developer specific Gemfile
 dev_gemfile = File.expand_path("Gemfile.dev.rb", __dir__)
 eval_gemfile(dev_gemfile) if File.exist?(dev_gemfile)
-
-minimum_version =
-  case ENV['TEST_RAILS_VERSION']
-  when "6.0"
-    "~>6.0.4"
-  when "7.0"
-    "~>7.0.8"
-  else
-    "~>6.1.4"
-  end
-
-gem "activesupport", minimum_version

--- a/lib/manageiq/api/client.rb
+++ b/lib/manageiq/api/client.rb
@@ -3,7 +3,6 @@ require "active_support/core_ext"
 require "faraday"
 require "faraday_middleware"
 require "json"
-require "pp"
 require "query_relation"
 
 require "manageiq/api/client/client"

--- a/lib/manageiq/api/client.rb
+++ b/lib/manageiq/api/client.rb
@@ -3,7 +3,6 @@ require "active_support/core_ext"
 require "faraday"
 require "faraday_middleware"
 require "json"
-require "more_core_extensions/all"
 require "pp"
 require "query_relation"
 

--- a/lib/manageiq/api/client/connection.rb
+++ b/lib/manageiq/api/client/connection.rb
@@ -105,7 +105,7 @@ module ManageIQ
 
         def check_response
           if response.status == 404
-            message = json_response.fetch_path("error", "message") || json_response["error"]
+            message = json_response["error"].kind_of?(String) ? json_response["error"] : json_response.dig("error", "message")
             raise ManageIQ::API::Client::ResourceNotFound, message
           elsif response.status >= 400
             @error = ManageIQ::API::Client::Error.new(response.status, json_response)

--- a/manageiq-api-client.gemspec
+++ b/manageiq-api-client.gemspec
@@ -27,7 +27,6 @@ Gem::Specification.new do |spec|
   spec.add_dependency "faraday", "~> 1.0"
   spec.add_dependency "faraday_middleware", "~> 1.0"
   spec.add_dependency "json", "~> 2.3"
-  spec.add_dependency "more_core_extensions"
   spec.add_dependency "query_relation"
 
   spec.add_development_dependency "bundler"

--- a/manageiq-api-client.gemspec
+++ b/manageiq-api-client.gemspec
@@ -23,7 +23,6 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "activesupport", ">= 6.0", "<7.1"
   spec.add_dependency "faraday", "~> 1.0"
   spec.add_dependency "faraday_middleware", "~> 1.0"
   spec.add_dependency "json", "~> 2.3"


### PR DESCRIPTION
https://github.com/ManageIQ/query_relation/pull/31 removes these same dependencies from query_relation

Before
======

```ruby
# Gemfile

gem "manageiq-api-client"
```

```
bundle update
=> 26 gems
```

After
=====

```
bundle update
=> 12 gems
```

