### PR TITLE
Revert drop activesupport dependency

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,7 +15,12 @@ jobs:
         - '2.7'
         - '3.0'
         - '3.1'
+        rails-version:
+        - '6.0'
+        - '6.1'
+        - '7.0'
     env:
+      TEST_RAILS_VERSION: ${{ matrix.rails-version }}
       CC_TEST_REPORTER_ID: ${{ secrets.CC_TEST_REPORTER_ID }}
     steps:
     - uses: actions/checkout@v4
@@ -28,6 +33,6 @@ jobs:
     - name: Run tests
       run: bundle exec rake
     - name: Report code coverage
-      if: ${{ github.ref == 'refs/heads/master' && matrix.ruby-version == '3.0' }}
+      if: ${{ github.ref == 'refs/heads/master' && matrix.ruby-version == '3.0' && matrix.rails-version == '6.1' }}
       continue-on-error: true
       uses: paambaati/codeclimate-action@v5

--- a/Gemfile
+++ b/Gemfile
@@ -6,3 +6,15 @@ gemspec
 # Load developer specific Gemfile
 dev_gemfile = File.expand_path("Gemfile.dev.rb", __dir__)
 eval_gemfile(dev_gemfile) if File.exist?(dev_gemfile)
+
+minimum_version =
+  case ENV['TEST_RAILS_VERSION']
+  when "6.0"
+    "~>6.0.4"
+  when "7.0"
+    "~>7.0.8"
+  else
+    "~>6.1.4"
+  end
+
+gem "activesupport", minimum_version

--- a/lib/manageiq/api/client.rb
+++ b/lib/manageiq/api/client.rb
@@ -2,6 +2,7 @@ require "active_support"
 require "active_support/core_ext"
 require "faraday"
 require "faraday_middleware"
+require 'forwardable'
 require "json"
 require "query_relation"
 

--- a/lib/manageiq/api/client/client.rb
+++ b/lib/manageiq/api/client/client.rb
@@ -1,6 +1,7 @@
 module ManageIQ
   module API
     class Client
+      extend Forwardable
       attr_reader :client_options
       attr_reader :logger
       attr_reader :url
@@ -62,7 +63,7 @@ module ManageIQ
         load_definitions
       end
 
-      delegate :get, :post, :put, :patch, :delete, :options, :error, :to => :connection
+      def_delegators :connection, :get, :post, :put, :patch, :delete, :options, :error
 
       private
 

--- a/lib/manageiq/api/client/connection.rb
+++ b/lib/manageiq/api/client/connection.rb
@@ -58,12 +58,12 @@ module ManageIQ
         end
 
         def api_path(path)
-          if path.to_s.starts_with?(url.to_s)
+          if path.to_s.start_with?(url.to_s)
             path.to_s
           elsif path.to_s.blank?
             URI.join(url, API_PREFIX).to_s
           else
-            URI.join(url, path.to_s.starts_with?(API_PREFIX) ? path.to_s : "#{API_PREFIX}/#{path}").to_s
+            URI.join(url, path.to_s.start_with?(API_PREFIX) ? path.to_s : "#{API_PREFIX}/#{path}").to_s
           end
         end
 

--- a/lib/manageiq/api/client/connection.rb
+++ b/lib/manageiq/api/client/connection.rb
@@ -2,6 +2,8 @@ module ManageIQ
   module API
     class Client
       class Connection
+        extend Forwardable
+
         attr_reader :url
         attr_reader :authentication
         attr_reader :client
@@ -9,7 +11,7 @@ module ManageIQ
         attr_reader :response
         attr_reader :error
 
-        delegate :url, :authentication, :to => :client
+        def_delegators :client, :url, :authentication
 
         API_PREFIX = "/api".freeze
         CONTENT_TYPE = "application/json".freeze

--- a/lib/manageiq/api/client/resource.rb
+++ b/lib/manageiq/api/client/resource.rb
@@ -2,6 +2,7 @@ module ManageIQ
   module API
     class Client
       class Resource
+        extend Forwardable
         include ActionMixin
 
         CUSTOM_INSPECT_EXCLUSIONS = [:@collection].freeze
@@ -21,7 +22,7 @@ module ManageIQ
         attr_reader :collection
         attr_reader :actions
 
-        delegate :client, :to => :collection
+        def_delegators :collection, :client
 
         def initialize(collection, resource_hash)
           raise "Cannot instantiate a Resource directly" if instance_of?(Resource)

--- a/manageiq-api-client.gemspec
+++ b/manageiq-api-client.gemspec
@@ -23,6 +23,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
+  spec.add_dependency "activesupport", ">= 6.0", "<7.1"
   spec.add_dependency "faraday", "~> 1.0"
   spec.add_dependency "faraday_middleware", "~> 1.0"
   spec.add_dependency "json", "~> 2.3"


### PR DESCRIPTION
Dropped active support in #115 but there are still a bunch of uses.

Specifically: `blank?`, `present?`, `camelcase`, `classify`, and `ActiveSupport::Concern`.

PR contains:

- revert: drop active support dependency
- use standard ruby `start_with`
- use standard ruby `forwardable`