### PR TITLE
Raise exceptions on empty responses

### DIFF
--- a/lib/manageiq/api/client/connection.rb
+++ b/lib/manageiq/api/client/connection.rb
@@ -111,7 +111,7 @@ module ManageIQ
             raise ManageIQ::API::Client::ResourceNotFound, message
           elsif response.status >= 400
             @error = ManageIQ::API::Client::Error.new(response.status, json_response)
-            raise @error.message
+            raise ManageIQ::API::Client::Exception, @error.message || "Empty Response"
           end
         end
       end


### PR DESCRIPTION
Before
======

If connecting to a host and a firewall blocks the message, The message would be empty and this would throw a strange exception.

```
lib/manageiq/api/client/connection.rb:112:in `raise': exception class/object expected (TypeError)
  raise @error.message
        ^^^^^^^^^^^^^^
    from lib/manageiq/api/client/connection.rb:112:in `check_response'
    from lib/manageiq/api/client/connection.rb:103:in `send_request'
    from lib/manageiq/api/client/connection.rb:24:in `get'
    from lib/manageiq/api/client/client.rb:37:in `load_definitions'
    from lib/manageiq/api/client/client.rb:62:in `reconnect'
    from lib/manageiq/api/client/client.rb:33:in `initialize'
```

After
=====

If the message is empty, give some message and raise original exception

```
lib/manageiq/api/client/connection.rb:114:in `check_response': Empty Response (ManageIQ::API::Client::Exception)
    from lib/manageiq/api/client/connection.rb:105:in `send_request'
    from lib/manageiq/api/client/connection.rb:26:in `get'
    from lib/manageiq/api/client/client.rb:38:in `load_definitions'
    from lib/manageiq/api/client/client.rb:63:in `reconnect'
    from lib/manageiq/api/client/client.rb:34:in `initialize'
    from ./list-providers.rb:18:in `new'
    from ./list-providers.rb:18:in `<main>'
```

<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
