### PR TITLE
upgrade faraday from 1.0 to 2.0

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,7 +12,6 @@ jobs:
     strategy:
       matrix:
         ruby-version:
-        - '2.7'
         - '3.0'
         - '3.1'
         rails-version:

--- a/lib/manageiq/api/client.rb
+++ b/lib/manageiq/api/client.rb
@@ -1,7 +1,7 @@
 require "active_support"
 require "active_support/core_ext"
 require "faraday"
-require "faraday_middleware"
+require "faraday/follow_redirects"
 require 'forwardable'
 require "json"
 require "query_relation"

--- a/lib/manageiq/api/client/connection.rb
+++ b/lib/manageiq/api/client/connection.rb
@@ -76,10 +76,11 @@ module ManageIQ
             faraday.options.open_timeout = @connection_options[:open_timeout] if @connection_options[:open_timeout]
             faraday.options.timeout      = @connection_options[:timeout]      if @connection_options[:timeout]
             faraday.response(:logger, client.logger)
-            faraday.use FaradayMiddleware::FollowRedirects, :limit => 3, :standards_compliant => true
-            faraday.adapter(Faraday.default_adapter) # make requests with Net::HTTP
+            faraday.response(:follow_redirects, :limit => 3, :standards_compliant => true)
+            # make requests with Net::HTTP
+            faraday.adapter(Faraday.default_adapter)
             if authentication.token.blank? && authentication.miqtoken.blank? && authentication.bearer_token.blank?
-              faraday.basic_auth(authentication.user, authentication.password)
+              faraday.request(:authorization, :basic, authentication.user, authentication.password)
             end
           end
         end

--- a/manageiq-api-client.gemspec
+++ b/manageiq-api-client.gemspec
@@ -24,8 +24,8 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "activesupport", ">= 6.0", "<7.1"
-  spec.add_dependency "faraday", "~> 1.0"
-  spec.add_dependency "faraday_middleware", "~> 1.0"
+  spec.add_dependency "faraday", "~> 2.9"
+  spec.add_dependency "faraday-follow_redirects"
   spec.add_dependency "json", "~> 2.3"
   spec.add_dependency "query_relation"
 


### PR DESCRIPTION
faraday 2.0 uses different middleware.
Upgraded to use follow_redirects.

faraday 2.0 has been split up to use many http client libraries Using net-http, so this avoids requiring a dozen adapter gems

---

I would like to test this with tasks to ensure it all still works

Faraday 2.0 only supports ruby 3.0 and higher. had to drop testing (and supporting) ruby 2.7