### PR TITLE
Use core minimum but allow 7.0/7.1/7.2 since core sets upper limit

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,10 +14,15 @@ jobs:
         ruby-version:
         - '3.0'
         - '3.1'
+        - '3.2'
+        - '3.3'
         rails-version:
-        - '6.0'
-        - '6.1'
         - '7.0'
+        - '7.1'
+        - '7.2'
+        exclude:
+        - ruby-version: '3.0'
+          rails-version: '7.2'
     env:
       TEST_RAILS_VERSION: ${{ matrix.rails-version }}
       CC_TEST_REPORTER_ID: ${{ secrets.CC_TEST_REPORTER_ID }}

--- a/Gemfile
+++ b/Gemfile
@@ -9,12 +9,12 @@ eval_gemfile(dev_gemfile) if File.exist?(dev_gemfile)
 
 minimum_version =
   case ENV['TEST_RAILS_VERSION']
-  when "6.0"
-    "~>6.0.4"
-  when "7.0"
-    "~>7.0.8"
+  when "7.2"
+    "~>7.2.1"
+  when "7.1"
+    "~>7.1.4"
   else
-    "~>6.1.4"
+    "~>7.0.8"
   end
 
 gem "activesupport", minimum_version

--- a/manageiq-api-client.gemspec
+++ b/manageiq-api-client.gemspec
@@ -23,7 +23,9 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "activesupport", ">= 6.0", "<7.1"
+  spec.required_ruby_version = '>= 3.0'
+
+  spec.add_dependency "activesupport", ">= 7.0", "<8.0"
   spec.add_dependency "faraday", ">= 1.0", "< 3.0"
   spec.add_dependency "faraday-follow_redirects"
   spec.add_dependency "json", "~> 2.3"


### PR DESCRIPTION
Drop end of life rubies and rails and add new versions

Ensure we're testing and supporting community supported versions.

Drop:
* rails 6.0
* rails 6.1

Add:
* ruby 3.2
* ruby 3.3
* rails 7.1
* rails 7.2

Note: ruby 3.0 is not difficult to keep maintaining for now but it's on the chopping block.

<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
