### PR TITLE
Fix issues where active_support does not require logger properly

### DIFF
--- a/lib/manageiq/api/client.rb
+++ b/lib/manageiq/api/client.rb
@@ -1,3 +1,4 @@
+require "logger" # Require logger due to active_support breaking on Rails <= 7.0. See https://github.com/rails/rails/pull/54264
 require "active_support"
 require "active_support/core_ext"
 require "faraday"

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -12,6 +12,5 @@ def api_file_fixture(path)
   File.read(File.join("spec/fixtures/api/", path))
 end
 
-require "active_support"
 puts
 puts "\e[93mUsing ActiveSupport #{ActiveSupport.version}\e[0m"


### PR DESCRIPTION
Require logger due to active_support breaking on Rails <= 7.0. See https://github.com/rails/rails/pull/54264

@jrafanie Please review.