### PR TITLE
JSON 2.17 won't parse this invalid escape sequence

### DIFF
--- a/spec/fixtures/api/responses/entrypoint.json
+++ b/spec/fixtures/api/responses/entrypoint.json
@@ -271,7 +271,7 @@
     {
       "name": "notifications",
       "href": "http://localhost:3000/api/notifications",
-      "description": "User\'s past notifications"
+      "description": "User's past notifications"
     },
     {
       "name": "orchestration_templates",


### PR DESCRIPTION
I've verified we don't dump that invalid escape sequence on current master so it's been fixed for a long time but the circa 2016 json file was not.

JSON 2.17.0 has:
"Fix the parser to no longer ignore invalid escapes in strings. Only \", \\, \b, \f, \n, \r, \t and \u are valid JSON escapes."

https://github.com/ruby/json/blob/master/CHANGES.md#2025-12-03-2170

<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
